### PR TITLE
Fix HTML entity references in text content across multiple components

### DIFF
--- a/app/shows/[id]/page.tsx
+++ b/app/shows/[id]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Header from "@/components/Header";
-import { type ShowMeta } from "@/components/ShowCard";
 import Link from "next/link";
 import { allShows } from "@/lib/showsData";
 import { zareKeKanaSegments } from "@/lib/zareKeKanaSegments";

--- a/app/shows/page.tsx
+++ b/app/shows/page.tsx
@@ -30,7 +30,7 @@ export default function ShowsPage() {
               Shows
             </h1>
             <p className="mt-3 text-lg text-white/90 max-w-2xl">
-              Ethiopia's full-spectrum TV - Dubbed dramas, original content, news, documentaries, music, and more
+              Ethiopia&apos;s full-spectrum TV - Dubbed dramas, original content, news, documentaries, music, and more
             </p>
           </div>
         </div>

--- a/components/KanaWarehouse.tsx
+++ b/components/KanaWarehouse.tsx
@@ -140,7 +140,7 @@ export default function KanaWarehouse() {
         >
           <h3 className="text-2xl font-semibold mb-4">About the Venue</h3>
           <p className="text-white/80 leading-relaxed mb-4">
-            Kana Warehouse is Addis Ababa's most versatile event and concert venue.
+            Kana Warehouse is Addis Ababa&apos;s most versatile event and concert venue.
             The 13-meter-high, column-free hall spans 1,200 square meters indoors,
             with a compact capacity of 2,000 for standing (1,000 for seated).
           </p>

--- a/components/ShowsByCategory.tsx
+++ b/components/ShowsByCategory.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from "react";
 import { motion } from "framer-motion";
-import ShowCard, { type ShowMeta } from "@/components/ShowCard";
+import ShowCard from "@/components/ShowCard";
 import { showCategories } from "@/lib/showsData";
 
 export default function ShowsByCategory() {


### PR DESCRIPTION
- Updated text in `page.tsx` and `KanaWarehouse.tsx` to use HTML entity references for apostrophes, ensuring proper rendering.
- Removed unused import of `ShowMeta` in `ShowsByCategory.tsx` for cleaner code.